### PR TITLE
feat: prepare packages for npm publishing

### DIFF
--- a/packages/core-ui/README.md
+++ b/packages/core-ui/README.md
@@ -25,9 +25,9 @@ Optimized for building fast, scalable web applications—especially dashboards a
 ### 1. Install the package
 
 ```
-yarn add core-kit
+yarn add @core-kit/core-ui
 # or
-npm install core-kit
+npm install @core-kit/core-ui
 
 ```
 
@@ -53,7 +53,7 @@ Add the library to your Tailwind content paths so its styles are detected:
 module.exports = {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
-    "./node_modules/core-kit/**/*.{js,jsx,ts,tsx}"
+    "./node_modules/@core-kit/core-ui/**/*.{js,jsx,ts,tsx}"
   ],
   theme: {
     extend: {},

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "core-kit",
+  "name": "@core-kit/core-ui",
   "author": {
     "name": "warjamma",
     "email": "5lgold141@gmail.com",
@@ -11,12 +11,22 @@
   },
   "description": "Corekit",
   "main": "./dist/exports.js",
+  "module": "./dist/exports.mjs",
+  "types": "./dist/exports.d.ts",
   "files": [
     "dist"
   ],
   "exports": {
-    ".": "./dist/exports.js",
-    "./client": "./dist/export-client.js",
+    ".": {
+      "require": "./dist/exports.js",
+      "import": "./dist/exports.mjs",
+      "types": "./dist/exports.d.ts"
+    },
+    "./client": {
+      "require": "./dist/export-client.js",
+      "import": "./dist/export-client.mjs",
+      "types": "./dist/export-client.d.ts"
+    },
     "./styles/styles.css": "./dist/styles/styles.css"
   },
   "scripts": {

--- a/packages/core-utilities/README.md
+++ b/packages/core-utilities/README.md
@@ -25,9 +25,9 @@ Optimized for building fast, scalable web applications—especially dashboards a
 ### 1. Install the package
 
 ```
-yarn add core-kit
+yarn add @core-kit/core-utilities
 # or
-npm install core-kit
+npm install @core-kit/core-utilities
 
 ```
 
@@ -53,7 +53,7 @@ Add the library to your Tailwind content paths so its styles are detected:
 module.exports = {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
-    "./node_modules/core-kit/**/*.{js,jsx,ts,tsx}"
+    "./node_modules/@core-kit/core-utilities/**/*.{js,jsx,ts,tsx}"
   ],
   theme: {
     extend: {},

--- a/packages/core-utilities/package.json
+++ b/packages/core-utilities/package.json
@@ -11,12 +11,22 @@
   },
   "description": "Corekit",
   "main": "./dist/exports.js",
+  "module": "./dist/exports.mjs",
+  "types": "./dist/exports.d.ts",
   "files": [
     "dist"
   ],
   "exports": {
-    ".": "./dist/exports.js",
-    "./client": "./dist/export-client.js"
+    ".": {
+      "require": "./dist/exports.js",
+      "import": "./dist/exports.mjs",
+      "types": "./dist/exports.d.ts"
+    },
+    "./client": {
+      "require": "./dist/export-client.js",
+      "import": "./dist/export-client.mjs",
+      "types": "./dist/export-client.d.ts"
+    }
   },
   "scripts": {
     "next:dev": "next dev",


### PR DESCRIPTION
## Summary
- scope core packages under `@core-kit` and add module/typing metadata for npm
- document new scoped packages in installation and Tailwind setup guides

## Testing
- `yarn build` *(fails: Package for @core-kit/core-ui@workspace:. not found in the project)*

------
https://chatgpt.com/codex/tasks/task_e_6895c454e48083248ec103327e1ef982