### PR TITLE
Align package TypeScript configs with root base config

### DIFF
--- a/packages/core-ui/tsconfig.json
+++ b/packages/core-ui/tsconfig.json
@@ -1,13 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -18,6 +14,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/core-utilities/package.json
+++ b/packages/core-utilities/package.json
@@ -34,7 +34,8 @@
     "next:start": "next start",
     "next:lint": "next lint",
     "build": "rm -rf dist && tsup src/exports.ts --format esm,cjs --dts --minify --tsconfig tsconfig.tsup.json --external react,react-dom",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "lint": "next lint"
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",

--- a/packages/core-utilities/tsconfig.json
+++ b/packages/core-utilities/tsconfig.json
@@ -1,13 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -18,6 +14,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "./packages/core-ui" },
+    { "path": "./packages/core-utilities" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add root tsconfig referencing workspace packages
- simplify package tsconfig files to extend shared base config
- expose lint script for core-utilities package

## Testing
- `npm run lint --prefix packages/core-ui`
- `npm run lint --prefix packages/core-utilities` *(fails: Couldn't find any `pages` or `app` directory)*
- `npm run build --prefix packages/core-ui`
- `npm run build --prefix packages/core-utilities`


------
https://chatgpt.com/codex/tasks/task_e_6895c70bed90832485e442d365501b4f